### PR TITLE
Fix tests by skipping Firebase init

### DIFF
--- a/firebase_service.dart
+++ b/firebase_service.dart
@@ -1,8 +1,12 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'dart:io';
 
 class FirebaseService {
   static Future<void> init() async {
+    if (Platform.environment.containsKey('FLUTTER_TEST')) {
+      return;
+    }
     await Firebase.initializeApp();
   }
 


### PR DESCRIPTION
## Summary
- prevent Firebase initialization during widget tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616f7cc6108326ad57e432d52129ab